### PR TITLE
Wait for elastic search to start and then index the wiki

### DIFF
--- a/extra-entrypoint-run-first.sh
+++ b/extra-entrypoint-run-first.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-#/wait-for-it.sh $MW_ELASTIC_HOST:$MW_ELASTIC_PORT -t 300
+/wait-for-it.sh $MW_ELASTIC_HOST:$MW_ELASTIC_PORT -t 300

--- a/extra-install.sh
+++ b/extra-install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-#php /var/www/html/extensions/CirrusSearch/maintenance/UpdateSearchIndexConfig.php
-#php /var/www/html/extensions/CirrusSearch/maintenance/ForceSearchIndex.php --skipParse
-#php /var/www/html/extensions/CirrusSearch/maintenance/ForceSearchIndex.php --skipLinks --indexOnSkip
+php /var/www/html/extensions/CirrusSearch/maintenance/UpdateSearchIndexConfig.php
+php /var/www/html/extensions/CirrusSearch/maintenance/ForceSearchIndex.php --skipParse
+php /var/www/html/extensions/CirrusSearch/maintenance/ForceSearchIndex.php --skipLinks --indexOnSkip
 
 n=0
 until [ $n -ge 5 ]


### PR DESCRIPTION
# MaRDI Pull Request
Wiki was not indexed any more, as indexing failed on startup 

https://github.com/MaRDI4NFDI/portal-compose/issues/106

**Changes**:
- Wait for elastic search to start
- run indexing

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
