### PR TITLE
Added recurse-submodules to script that clones extensions

### DIFF
--- a/clone-extension.sh
+++ b/clone-extension.sh
@@ -6,5 +6,5 @@ BRANCH=$2
 #git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/$EXTENSiON -b ${BRANCH} ${EXTENSION} \
 #|| git clone https://github.com/wikimedia/mediawiki-extensions-${EXTENSION}.git -b ${BRANCH} ${EXTENSION}
 
-git clone https://github.com/wikimedia/mediawiki-extensions-${EXTENSION}.git -b ${BRANCH} ${EXTENSION}
+git clone --recurse-submodules https://github.com/wikimedia/mediawiki-extensions-${EXTENSION}.git -b ${BRANCH} ${EXTENSION}
 rm -rf ${EXTENSION}/.git


### PR DESCRIPTION
# MaRDI Pull Request
I had forgotten to do recurse submodules when cloning the extensions from their repos. This causes a javascript error in the search box. You can see the error in the javascript console.

**Changes**:
- the clone-extension script now clones submodules too
- I checked if the extensions that are cloned from other services than Github (not using the clone-extensions script) require recurse-submodules flag, none does

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
