### PR TITLE
Define loading order of files in LocalSettings

### DIFF
--- a/LocalSettings.php.mardi.template
+++ b/LocalSettings.php.mardi.template
@@ -3,7 +3,16 @@
 ${DOLLAR}wgWBRepoSettings['wikibasePingback'] = false;
 
 # Load additional settings from LocalSettings.d
+/*
+To make loading order deterministic and to identify errors when loading the script, this script orders the include of settings.
+
+1) Include Localsettings in alphabetic order ignoring the extensions.
+2) Include Extensions in alphabetic order
+*/
+
 # Generate list of extensions
+${DOLLAR}extensionList = array();
+${DOLLAR}extensionsToLoad = array();
 foreach (glob("{${DOLLAR}wgExtensionDirectory}/*", GLOB_ONLYDIR) as ${DOLLAR}extension)
 {
     ${DOLLAR}extensionList[] = basename(${DOLLAR}extension);

--- a/LocalSettings.php.mardi.template
+++ b/LocalSettings.php.mardi.template
@@ -1,11 +1,22 @@
 
-#Pingback
+# Pingback
 ${DOLLAR}wgWBRepoSettings['wikibasePingback'] = false;
 
-# load additional setting from LocalSettings.d
+# Load additional settings from LocalSettings.d
+# Generate list of extensions
+foreach (glob("{${DOLLAR}wgExtensionDirectory}/*", GLOB_ONLYDIR) as ${DOLLAR}extension)
+{
+    ${DOLLAR}extensionList[] = basename(${DOLLAR}extension);
+}
+
+# Load settings alphabetically and save extension list
 foreach (glob("/shared/LocalSettings.d/*.php") as ${DOLLAR}filename)
+{
+    in_array(basename(${DOLLAR}filename, ".php"), ${DOLLAR}extensionList) ? ${DOLLAR}extensionsToLoad[] = ${DOLLAR}filename : include ${DOLLAR}filename;
+}
+
+# Load extensions list alphabetically
+foreach (${DOLLAR}extensionsToLoad as ${DOLLAR}filename)
 {
     include ${DOLLAR}filename;
 }
-
-


### PR DESCRIPTION
# MaRDI Pull Request
https://github.com/MaRDI4NFDI/docker-wikibase/issues/18

**Changes**:
- Define the loading order of all files inside LocalSettings.d. 
- First the settings are loaded and then the extensions (alphabetically).

**Instructions for PR review**:
- [X] Conceptual Review (Logic etc...) 
- [X] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [X] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [X] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
