### PR TITLE
Revert error_reporting declaration

### DIFF
--- a/LocalSettings.php.mardi.template
+++ b/LocalSettings.php.mardi.template
@@ -29,5 +29,3 @@ foreach (${DOLLAR}extensionsToLoad as ${DOLLAR}filename)
 {
     include ${DOLLAR}filename;
 }
-
-error_reporting = E_ALL & ~E_DEPRECATED;


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Since changes in LocalSettings.php.mardi.template (see https://github.com/MaRDI4NFDI/docker-wikibase/pull/33) are not automatically deployed, it is better to deactivate Deprecation warnings through 'display_errors' in portal-compose.


**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
