### PR TITLE
Define Docker ARG at the top

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 ######################
 #   global settings  #
 ######################
-
 ARG MEDIAWIKI_VERSION=1.38.1
+ARG WMF_BRANCH=wmf/1.39.0-wmf.16
+ARG REL_BRANCH=REL1_38
+ARG WMDE_BRANCH=wmde.6
 
 ################
 #   fetcher    #
@@ -14,12 +16,12 @@ RUN apt-get update && \
     apt-get install --reinstall ca-certificates && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# fetcher specific settings
-# clone extensions from github, using specific branch
-ARG WMF_BRANCH=wmf/1.39.0-wmf.13
-ARG REL_BRANCH=REL1_38
-ARG WMDE_BRANCH=wmde.6
+# make global settings known in this build stage
+ARG WMF_BRANCH
+ARG REL_BRANCH
+ARG WMDE_BRANCH
 
+# clone extensions from github, using specific branch
 
 COPY clone-extension.sh .
 
@@ -82,7 +84,7 @@ rm -rf mediawiki/.git
 ################
 #  collector   #
 ################
-FROM mediawiki:${MEDIAWIKI_VERSION}  as collector
+FROM mediawiki:${MEDIAWIKI_VERSION} as collector
 
 COPY --from=fetcher /mediawiki /var/www/html
 # collect bundle extensions


### PR DESCRIPTION
some caveats. in multi stage builds, Docker ARG defined before the first FROM, are only defined in FROM statements (`FROM ubuntu:$VERSION`), but not within the build stages.Make "global" args known inside of the build stages is possible by calling eg `ARG VERSION` after the FROM statement (in the build stage scope).


**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
