### PR TITLE
Fix deprecation warnings in production

### DIFF
--- a/LocalSettings.php.template
+++ b/LocalSettings.php.template
@@ -53,3 +53,9 @@ wfLoadExtension( 'WikibaseRepository', "${DOLLAR}IP/extensions/Wikibase/extensio
 require_once "${DOLLAR}IP/extensions/Wikibase/repo/ExampleSettings.php";
 wfLoadExtension( 'WikibaseClient', "${DOLLAR}IP/extensions/Wikibase/extension-client.json" );
 require_once "${DOLLAR}IP/extensions/Wikibase/client/ExampleSettings.php";
+
+# Production env
+${DOLLAR}productionComparator = 'prod';
+if (${DOLLAR}productionComparator == '${DEPLOYMENT_ENV}') {
+    ${DOLLAR}wgDeprecationReleaseLimit = '1.20';
+}


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- upon start of mardi-wikibase env vars are read by entrypoint.sh to determine prod or
- conditionally deprecation warnings are set or not 
- currently settings file shared isn't automatically overwritten, but i left it for now. 


**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [x] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
