### PR TITLE
chown images directory to www-data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -212,7 +212,10 @@ RUN mkdir /shared
 COPY regular_maintenance.sh /var/www/html/regular_maintenance.sh
 RUN chmod ugo+rwx /var/www/html/regular_maintenance.sh
 RUN echo "* */1 * * *      root   /var/www/html/regular_maintenance.sh > /var/www/html/regular_maintenance.log"  \
-    >> /etc/cron.d/regular_maintenance
+    >> /etc/cron.d/Regular_maintenance
+
+# set ownership of the uploaded images directory
+RUN chown www-data:www-data /var/www/html/images
 
 #########################
 # Set up vecollabpad    #


### PR DESCRIPTION
# MaRDI Pull Request

fixes #49 

**Changes**:
- set owner of `/var/www/html/images` to www-data (apache user), such that file upload is possible from the start


**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
