### PR TITLE
add logrotate (use default config)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -176,7 +176,7 @@ FROM mediawiki:${MEDIAWIKI_VERSION}
 # NAME="Debian GNU/Linux"
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive\
-    apt-get install --yes --no-install-recommends nano jq=1.* libbz2-dev=1.* gettext-base npm grunt cron vim librsvg2-bin && \
+    apt-get install --yes --no-install-recommends nano jq=1.* libbz2-dev=1.* gettext-base npm grunt cron vim librsvg2-bin logrotate && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite
@@ -224,6 +224,7 @@ RUN chown www-data:www-data /var/www/html/images
 #########################
 RUN cd /var/www/html/extensions/VisualEditor/lib/ve && npm install && grunt build
 RUN cd /var/www/html/extensions/VisualEditor/lib/ve/rebaser && npm install && cp config.dev.yaml config.yaml && sed -i 's/localhost/mongodb/g' config.yaml
+
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/entrypoint.sh"]


### PR DESCRIPTION
# MaRDI Pull Request

install logrotate. apache logs setup is already in `/etc/logrotate.d/apache2`. a daily logrotate cronjob is automatically created (`/etc/cron.daily/logrotate`)

default setup will rotate daily and keep 14 rotations (i.e., 2 weeks).

rationale: since #61 apache logs are real files, hence a logrotation is useful to prevent huge logs

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
