### PR TITLE
undo apache log fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,14 +208,6 @@ RUN chmod ugo+rwx /var/www/html/regular_maintenance.sh
 RUN echo "* */1 * * *      root   /var/www/html/regular_maintenance.sh > /var/www/html/regular_maintenance.log"  \
     >> /etc/cron.d/Regular_maintenance
 
-# The php:7.4-apache docker image creates symlinks for /var/log/apache2/access.log and
-# error.log to /dev/stdout and /dev/stderr, such that the logs can be viewed with
-# `docker logs`. In order for a containerized log analyzer (goaccess) to read the actual
-# log files (processed with logrotate), this needs to be undone:
-RUN rm /var/log/apache2/access.log /var/log/apache2/error.log /var/log/apache2/other_vhosts_access.log 
-# NOTE: for docker logs to still show the logs, add tail -F access.log (etc) to
-# entrypoint.sh
-
 # set ownership of the uploaded images directory
 RUN chown www-data:www-data /var/www/html/images
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,10 +2,6 @@
 # This file is provided by the wikibase/wikibase docker image.
 
 
-tail -F -n 0 /var/log/access.log &
-tail -F -n 0 /var/log/other_vhosts_access.log &
-tail -F -n 0 /var/log/error.log 1>&2 &
-
 if [[ "${DB_SERVER:-}" ]]; then
   # Wait for the db to come up
   /wait-for-it.sh $DB_SERVER -t 300


### PR DESCRIPTION
# MaRDI Pull Request

undo #62 and #61

goaccess analyzes the traefik logs rather than apache logs, so the changes introducted by #62 #61  are not required anymore

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
