### PR TITLE
fix openidconnect ext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ COPY --from=fetcher /ExternalContent /var/www/html/extensions/ExternalContent
 COPY --from=fetcher /Plausible /var/www/html/extensions/Plausible
 COPY --from=fetcher /Shibboleth /var/www/html/extensions/Shibboleth
 COPY --from=fetcher /PluggableAuth /var/www/html/extensions/PluggableAuth
-COPY --from=fetcher /PluggableAuth /var/www/html/extensions/OpenIDConnect
+COPY --from=fetcher /OpenIDConnect /var/www/html/extensions/OpenIDConnect
 COPY --from=fetcher /MatomoAnalytics /var/www/html/extensions/MatomoAnalytics
 
 # extensions usd in wmflabs


### PR DESCRIPTION
# MaRDI Pull Request

due to #68 
```
Fatal error: Uncaught Exception: Unable to open file /var/www/html/extensions/OpenIDConnect/extension.json: filemtime(): stat failed for /var/www/html/extensions/OpenIDConnect/extension.json in /var/www/html/includes/registration/ExtensionRegistry.php:199 Stack trace: #0 /var/www/html/includes/GlobalFunctions.php(53): ExtensionRegistry->queue('/var/www/html/e...') #1 /shared/LocalSettings.d/OpenID_Connect.php(2): wfLoadExtension('OpenIDConnect') #2 /var/www/html/LocalSettings.php(113): include('/shared/LocalSe...') #3 /var/www/html/includes/Setup.php(218): require_once('/var/www/html/L...') #4 /var/www/html/includes/WebStart.php(86): require_once('/var/www/html/i...') #5 /var/www/html/index.php(44): require('/var/www/html/i...') #6 {main} thrown in /var/www/html/includes/registration/ExtensionRegistry.php on line 199
```
 this should fix the error

@physikerwelt 

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
