### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gh-actions-update.yml
+++ b/.github/workflows/gh-actions-update.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - 
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.0.0
       -
         name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,12 +32,12 @@ jobs:
       - 
         name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4.6.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - 
         name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4.1.1
         with:
           context: .
           push: true
@@ -45,7 +45,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       -
         name: Build and push Docker dev image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4.1.1
         with:
           context: dev
           push: true

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - 
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.0.0
       -
         name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -26,12 +26,12 @@ jobs:
       - 
         name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4.6.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - 
         name: Build Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4.1.1
         with:
           context: .
           push: false
@@ -39,7 +39,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       -
         name: Build Docker dev image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4.1.1
         with:
           context: dev
           push: false


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v4.1.1](https://github.com/docker/build-push-action/releases/tag/v4.1.1)** on 2023-06-13T11:22:58Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v4.6.0](https://github.com/docker/metadata-action/releases/tag/v4.6.0)** on 2023-06-13T10:28:40Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)** on 2023-09-04T12:22:57Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v2.2.0](https://github.com/docker/login-action/releases/tag/v2.2.0)** on 2023-06-07T13:07:43Z
