### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gh-actions-update.yml
+++ b/.github/workflows/gh-actions-update.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - 
         name: Checkout
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.1.0
       -
         name: Log in to the Container registry
         uses: docker/login-action@v3.0.0

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - 
         name: Checkout
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.1.0
       -
         name: Log in to the Container registry
         uses: docker/login-action@v3.0.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.0](https://github.com/actions/checkout/releases/tag/v4.1.0)** on 2023-09-22T17:42:49Z
