### PR TITLE
change order of maintenance scripts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,6 @@ if [ ! -e "/var/www/html/LocalSettings.php" ]; then
     done
     set -eu
     php /var/www/html/maintenance/install.php --dbuser "$DB_USER" --dbpass "$DB_PASS" --dbname "$DB_NAME" --dbserver "$DB_SERVER" --lang "$MW_SITE_LANG" --pass "$MW_ADMIN_PASS" "$MW_SITE_NAME" "$MW_ADMIN_NAME"
-    php /var/www/html/maintenance/resetUserEmail.php --no-reset-password "$MW_ADMIN_NAME" "$MW_ADMIN_EMAIL"
 
     # Copy our LocalSettings into place after install from the template
     # https://stackoverflow.com/a/24964089/4746236
@@ -50,6 +49,8 @@ if [ ! -e "/var/www/html/LocalSettings.php" ]; then
     if [ -f /extra-install.sh ]; then
         source /extra-install.sh
     fi
+
+    php /var/www/html/maintenance/resetUserEmail.php --no-reset-password "$MW_ADMIN_NAME" "$MW_ADMIN_EMAIL"
 fi
 
 # Copy LocalSettings to shared location


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- I moved the call to maintenance/resetUserEmail.php at the end of the loop for the first time wikibase is loaded.
- Otherwise, if maintenance scripts (resetUserEmail and createAndPromote) are called before running update.php, bootstrap is not detected and this triggers an error with the Skin chameleon:

Fatal error: Uncaught ExtensionDependencyError: chameleon requires Bootstrap to be installed.
in /var/www/html/includes/registration/ExtensionRegistry.php:460
Stack trace:
0 /var/www/html/includes/registration/ExtensionRegistry.php(314): ExtensionRegistry->readFromQueue(Array)
1 /var/www/html/includes/Setup.php(285): ExtensionRegistry->loadFromQueue()
2 /var/www/html/maintenance/doMaintenance.php(83): require_once('/var/www/html/i...')
3 /var/www/html/maintenance/resetUserEmail.php(98): require_once('/var/www/html/m...')
4 {main}
thrown in /var/www/html/includes/registration/ExtensionRegistry.php on line 460


**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
