### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.1.0
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v5.2.0
         with:
           context: .
           push: ${{ env.PUSH_IMAGE }}
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.1.0
       - name: Build and push Docker dev image
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v5.2.0
         with:
           context: dev
           push: ${{ env.PUSH_IMAGE }}
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.1.0
       - name: Build and push Docker jobrunner image
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v5.2.0
         with:
           context: jobrunner
           push: ${{ env.PUSH_IMAGE }}
@@ -114,7 +114,7 @@ jobs:
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@v3.1.0
         - name: Build and push Docker jobrunner image
-          uses: docker/build-push-action@v5.1.0
+          uses: docker/build-push-action@v5.2.0
           with:
             context: backup
             push: ${{ env.PUSH_IMAGE }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.2.0](https://github.com/docker/build-push-action/releases/tag/v5.2.0)** on 2024-03-08T08:00:44Z
