### PR TITLE
Remove custom modification to wgRCMaxAge

### DIFF
--- a/LocalSettings.php.template
+++ b/LocalSettings.php.template
@@ -39,13 +39,6 @@ ${DOLLAR}wgArticlePath = "/wiki/${DOLLAR}1";
 #Set Secret
 ${DOLLAR}wgSecretKey = "${MW_WG_SECRET_KEY}";
 
-## RC Age
-# https://www.mediawiki.org/wiki/Manual:$wgRCMaxAge
-# Items in the recentchanges table are periodically purged; entries older than this many seconds will go.
-# The query service (by default) loads data from recent changes
-# Set this to 1 year to avoid any changes being removed from the RC table over a shorter period of time.
-${DOLLAR}wgRCMaxAge = 365 * 24 * 3600;
-
 # Production env
 ${DOLLAR}productionComparator = 'prod';
 if (${DOLLAR}productionComparator == '${DEPLOYMENT_ENV}') {


### PR DESCRIPTION
Currently, we face issues that sometimes take a long time to  write in the recent changes table. While large table sizes are not a problem in general, 37M rows seems a bit large for an RC table.

Issue https://phabricator.wikimedia.org/T360410

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [x] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [x] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
