### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -36,9 +36,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.1.0
+        uses: docker/setup-buildx-action@v3.2.0
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5.2.0
+        uses: docker/build-push-action@v5.3.0
         with:
           context: .
           push: ${{ env.PUSH_IMAGE }}
@@ -56,15 +56,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.1.0
+        uses: docker/setup-buildx-action@v3.2.0
       - name: Build and push Docker dev image
-        uses: docker/build-push-action@v5.2.0
+        uses: docker/build-push-action@v5.3.0
         with:
           context: dev
           push: ${{ env.PUSH_IMAGE }}
@@ -81,15 +81,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.1.0
+        uses: docker/setup-buildx-action@v3.2.0
       - name: Build and push Docker jobrunner image
-        uses: docker/build-push-action@v5.2.0
+        uses: docker/build-push-action@v5.3.0
         with:
           context: jobrunner
           push: ${{ env.PUSH_IMAGE }}
@@ -106,15 +106,15 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v4.1.1
         - name: Log in to the Container registry
-          uses: docker/login-action@v3.0.0
+          uses: docker/login-action@v3.1.0
           with:
             registry: ${{ env.REGISTRY }}
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3.1.0
+          uses: docker/setup-buildx-action@v3.2.0
         - name: Build and push Docker jobrunner image
-          uses: docker/build-push-action@v5.2.0
+          uses: docker/build-push-action@v5.3.0
           with:
             context: backup
             push: ${{ env.PUSH_IMAGE }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.2.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.2.0)** on 2024-03-14T08:24:16Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.3.0](https://github.com/docker/build-push-action/releases/tag/v5.3.0)** on 2024-03-14T08:32:47Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.1.0](https://github.com/docker/login-action/releases/tag/v3.1.0)** on 2024-03-13T15:11:17Z
