### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.6
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.6
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -81,7 +81,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.6
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -106,7 +106,7 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v4.1.6
         - name: Log in to the Container registry
-          uses: docker/login-action@v3.1.0
+          uses: docker/login-action@v3.2.0
           with:
             registry: ${{ env.REGISTRY }}
             username: ${{ github.actor }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.2.0](https://github.com/docker/login-action/releases/tag/v3.2.0)** on 2024-05-28T08:07:54Z
