### PR TITLE
Fix lua and xml backup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,7 +240,8 @@ FROM mediawiki:${MEDIAWIKI_VERSION}
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive\
     apt-get install --yes --no-install-recommends \
-    nano jq=1.* libbz2-dev=1.* gettext-base npm grunt cron vim librsvg2-bin libpq-dev libyaml-dev && \
+    nano jq=1.* libbz2-dev=1.* gettext-base npm grunt cron vim librsvg2-bin libpq-dev libyaml-dev \
+    lua5.1 liblua5.1-0-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -46,9 +46,12 @@ xml_dump() {
     echo
     echo "XML backup"
     XML_DUMP_FILE=portal_xml_backup_${DATE_STRING}.gz
+    # Relevant namespaces: https://portal.mardi4nfdi.de/wiki/Special:NamespaceInfo
+    NAMESPACES=(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 120 121 122 123 274 275 640 641 828 829 3000)
+    NAMESPACE_STR=$(IFS=,; echo "${NAMESPACES[*]}")
     # parsoid requires script to be executed from mw root
     cd /var/www/html/ || return 255
-    if /usr/local/bin/php /var/www/html/maintenance/dumpBackup.php --current --output=gzip:"${BACKUP_DIR}/${XML_DUMP_FILE}" --quiet --conf /shared/LocalSettings.php
+    if /usr/local/bin/php /var/www/html/maintenance/dumpBackup.php --current --output=gzip:"${BACKUP_DIR}/${XML_DUMP_FILE}" --quiet --filter=namespace:$NAMESPACE_STR --conf /shared/LocalSettings.php
     then
         STATUS=$?
         if [[ -f ${BACKUP_DIR}/${XML_DUMP_FILE} ]]; then


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Adding Lua development packages to fix this php warning:
```
Warning: PHP Startup: Unable to load dynamic library 'luasandbox' 
(tried: /usr/local/lib/php/extensions/no-debug-non-zts-20210902/luasandbox 
(/usr/local/lib/php/extensions/no-debug-non-zts-20210902/luasandbox: cannot open shared object file: No such file or directory), 
/usr/local/lib/php/extensions/no-debug-non-zts-20210902/luasandbox.so (liblua5.1.so.0: cannot open shared object file: No such file or directory)) in Unknown on line 0
```
- Filter namespaces in XML backup to include only those <= 3000. See [NamespaceInfo](https://portal.mardi4nfdi.de/wiki/Special:NamespaceInfo).

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
