### PR TITLE
Add option to run standalone wikibase container

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -1,0 +1,16 @@
+MW_SCRIPT_PATH=/
+MW_SERVER=http://localhost:8080
+MW_DOCKER_PORT=8080
+MEDIAWIKI_USER=Admin
+MEDIAWIKI_PASSWORD=dockerpass
+XDEBUG_CONFIG=
+XDEBUG_ENABLE=false
+XHPROF_ENABLE=false
+MW_SERVER=localhost
+MW_DBTYPE=sqlite
+MW_DBPATH=/var/www/html/cache/sqlite
+MW_LANG=en
+MW_USER=Admin
+MW_PASS=dockerpass
+MW_SITENAME=MediaWiki
+MW_LOG_DIR=/var/www/html/cache

--- a/entrypoint-standalone.sh
+++ b/entrypoint-standalone.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Do the mediawiki install (only if LocalSettings doesn't already exist)
+if [ ! -e "/var/www/html/LocalSettings.php" ]; then
+    set -euxo pipefail
+    php maintenance/install.php \
+      --server "$MW_SERVER" \
+      --scriptpath="$MW_SCRIPT_PATH" \
+      --dbtype "$MW_DBTYPE" \
+      --dbpath "$MW_DBPATH" \
+      --lang "$MW_LANG" \
+      --pass "$MW_PASS" \
+      --with-developmentsettings \
+      --skins Vector \
+      "$MW_SITENAME" "$MW_USER"
+    # Run update.php to install Wikibase
+    php /var/www/html/maintenance/update.php --quick
+fi
+
+# Run the actual entry point
+/usr/sbin/apache2ctl -D FOREGROUND
+

--- a/run-standalone-container.sh
+++ b/run-standalone-container.sh
@@ -1,0 +1,1 @@
+docker run --rm --env-file dev.env  -v "./entrypoint-standalone.sh:/entrypoint-standalone.sh"  --entrypoint /entrypoint-standalone.sh -p 8888:80 ghcr.io/mardi4nfdi/docker-wikibase:main 


### PR DESCRIPTION
Add a convince script to start the wikibase container as standalone instance. This is particularly useful for testing.

This PR does not change any files used in production.
