### PR TITLE
2gb upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -297,6 +297,7 @@ RUN chown www-data:www-data /var/www/html/w/images
 
 # Fix permissions for cache https://github.com/MaRDI4NFDI/portal-compose/pull/563
 RUN chmod 777 /var/www/html/w/cache
+COPY mardi_php.ini /usr/local/etc/php/conf.d/mardi_php.ini 
 
 # Copy shibboleth apache config
 # COPY shib_mod.conf /etc/apache2/conf-available

--- a/mardi_php.ini
+++ b/mardi_php.ini
@@ -1,0 +1,2 @@
+post_max_size = 2064M
+upload_max_filesize = 2048M


### PR DESCRIPTION
Increase maximum upload size to 2GB

See https://github.com/MaRDI4NFDI/portal-compose/issues/623

