### PR TITLE
Install WikibaseMediaInfo

### DIFF
--- a/clone_all.sh
+++ b/clone_all.sh
@@ -65,6 +65,7 @@ EXTENSIONS=(
  # "WikibaseLexeme ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikibaseLexeme.git"
   "WikibaseLocalMedia master https://github.com/ProfessionalWiki/WikibaseLocalMedia.git"
   "WikibaseManifest ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikibaseManifest.git"
+  "WikibaseMediaInfo ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikibaseMediaInfo.git"
   "WikibaseQualityConstraints ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikibaseQualityConstraints.git"
   "WikiEditor ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikiEditor.git"
   "YouTube ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-YouTube.git"


### PR DESCRIPTION
Needed by commonswiki

MWUnknownContentModelException from line 181 of /var/www/html/w/includes/content/ContentHandlerFactory.php: The content model 'wikibase-mediainfo' is not registered on this wiki. See https://www.mediawiki.org/wiki/Content_handlers to find out which extensions handle this content model.
