### PR TITLE
Configure remoteip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,12 @@ RUN apt-get update && \
 
 RUN a2enmod rewrite
 
+# Enable mod_remoteip to log real client IPs from X-Forwarded-For header
+RUN a2enmod remoteip
+COPY apache/remoteip.conf /etc/apache2/conf-available/remoteip.conf
+RUN a2enconf remoteip
+RUN sed -i 's/%h/%a/g' /etc/apache2/apache2.conf
+
 RUN install -d /var/log/mediawiki -o www-data
 RUN pecl install redis && docker-php-ext-enable redis
 RUN pecl install yaml && docker-php-ext-enable yaml

--- a/apache/remoteip.conf
+++ b/apache/remoteip.conf
@@ -1,0 +1,4 @@
+<IfModule remoteip_module>
+    RemoteIPHeader X-Forwarded-For
+    RemoteIPTrustedProxy 10.0.0.0/8
+</IfModule>


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Currently the mediawiki pod just shows the local IP corresponding to the traefik pod for all requests.
- This configures remoteip in apache so that we see the client IP reaching mediawiki.

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Apache mod_remoteip module to correctly identify and log actual client IP addresses instead of proxy server IPs, improving logging accuracy for environments behind a proxy or load balancer. Added X-Forwarded-For header support with configurable trusted proxy network settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->