### PR TITLE
Fix jobrunner build

### DIFF
--- a/jobrunner/Dockerfile
+++ b/jobrunner/Dockerfile
@@ -4,9 +4,12 @@ FROM ${BASE_IMAGE}
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions pcntl sockets gd zip redis
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+RUN apt-get update && apt-get install -y unzip git && rm -rf /var/lib/apt/lists/*
 RUN git clone --depth=1 https://github.com/wikimedia/mediawiki-services-jobrunner.git /jobrunner
 WORKDIR /jobrunner
-RUN composer install --no-dev
+RUN composer remove wikimedia/ip-set --no-update && \
+    composer require wikimedia/ip-utils:^5.0 --no-update && \
+    composer update --no-dev --prefer-dist
 COPY ./config.json /jobrunner/config.json
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- The jobrunner build is failing with this error:
```
#19 0.572 As there is no 'unzip' nor '7z' command installed zip files are being unpacked using the PHP zip extension.
#19 0.572 This may cause invalid reports of corrupted archives. Besides, any UNIX permissions (e.g. executable) defined in the archives will be lost.
#19 0.572 Installing 'unzip' or '7z' (21.01+) may remediate them.
#19 0.572   - Downloading wikimedia/at-ease (v2.1.0)
#19 0.573   - Downloading wikimedia/ip-set (3.1.0)
#19 0.573   - Downloading wikimedia/base-convert (v2.0.2)
#19 0.573   - Downloading wikimedia/ip-utils (4.0.0)
#19 0.578  0/4 [>---------------------------]   0%
#19 1.137  2/4 [==============>-------------]  50%    Failed to download wikimedia/ip-set from dist: The "https://codeload.github.com/wikimedia/mediawiki-libs-IPUtils/legacy.zip/9650ba486e21a84659fcfd46b3e5f2c4fa2b735c" file could not be downloaded (HTTP/2 404 )
#19 1.174     Now trying to download from source
#19 1.174   - Syncing wikimedia/ip-set (3.1.0) into cache
#19 1.666 
#19 1.666  3/4 [=====================>------]  75%
#19 1.676  4/4 [============================] 100%
#19 1.676   - Installing wikimedia/at-ease (v2.1.0): Extracting archive
#19 1.682   - Installing wikimedia/ip-set (3.1.0): Cloning 9650ba486e
#19 2.482     9650ba486e21a84659fcfd46b3e5f2c4fa2b735c is gone (history was rewritten?)
#19 2.482     Install of wikimedia/ip-set failed
#19 2.483   - Installing wikimedia/base-convert (v2.0.2): Extracting archive
#19 2.486   - Installing wikimedia/ip-utils (4.0.0): Extracting archive
#19 2.493     0 [>---------------------------]    0 [->--------------------------]
#19 2.844 In GitDownloader.php line 509:
#19 2.844                                                                                
#19 2.844   Failed to execute git checkout 9650ba486e21a84659fcfd46b3e5f2c4fa2b735c --   
#19 2.844   && git reset --hard 9650ba486e21a84659fcfd46b3e5f2c4fa2b735c --              
#19 2.844                                                                                
#19 2.844   fatal: unable to read tree (9650ba486e21a84659fcfd46b3e5f2c4fa2b735c)        
#19 2.844                                                                                
#19 2.844   It looks like the commit hash is not available in the repository, maybe the  
#19 2.844    tag was recreated? Run "composer update wikimedia/ip-set" to resolve this.  
#19 2.844                                                                                
#19 2.844 
#19 2.844 install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--download-only] [--dev] [--no-suggest] [--no-dev] [--no-autoloader] [--no-progress] [--no-install] [--audit] [--audit-format AUDIT-FORMAT] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]
#19 2.844 
#19 ERROR: process "/bin/sh -c composer install --no-dev" did not complete successfully: exit code: 1
------
 > [stage-0  7/10] RUN composer install --no-dev:
2.844   && git reset --hard 9650ba486e21a84659fcfd46b3e5f2c4fa2b735c --              
2.844                                                                                
2.844   fatal: unable to read tree (9650ba486e21a84659fcfd46b3e5f2c4fa2b735c)        
2.844                                                                                
2.844   It looks like the commit hash is not available in the repository, maybe the  
2.844    tag was recreated? Run "composer update wikimedia/ip-set" to resolve this.  
2.844                                                                                
2.844 
2.844 install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--download-only] [--dev] [--no-suggest] [--no-dev] [--no-autoloader] [--no-progress] [--no-install] [--audit] [--audit-format AUDIT-FORMAT] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]
2.844 
------
Dockerfile:9
--------------------
   7 |     RUN git clone --depth=1 https://github.com/wikimedia/mediawiki-services-jobrunner.git /jobrunner
   8 |     WORKDIR /jobrunner
   9 | >>> RUN composer install --no-dev
  10 |     COPY ./config.json /jobrunner/config.json
  11 |     COPY ./entrypoint.sh /entrypoint.sh
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c composer install --no-dev" did not complete successfully: exit code: 1
Reference
Check build summary support
Error: buildx failed with: ERROR: failed to build: failed to solve: process "/bin/sh -c composer install --no-dev" did not complete successfully: exit code: 1
```

I am modifying it to use wikimedia/ip-utils:^5.0 which should solve the problem with ip-set according to https://www.mediawiki.org/wiki/IPSet But I don't understand why this is not already applied in https://github.com/wikimedia/mediawiki-services-jobrunner

I am applying the change here for reference in case we have to roll it back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies to newer versions for improved compatibility and stability.
  * Optimized Docker image creation process to enhance build efficiency and layer management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->