### PR TITLE
Make the name of the apache-assets container non-ambitious

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -315,7 +315,7 @@ jobs:
           cache-from: type=gha,scope=apache
           cache-to: type=gha,mode=max,scope=apache
 
-  build-apache-assets:
+  build-apache-assets-production:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -339,18 +339,18 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5.10.0
         with:
-          images: ${{ env.REGISTRY }}/mardi4nfdi/apache_assets
+          images: ${{ env.REGISTRY }}/mardi4nfdi/apache-assets-production
           tags: |
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
           labels: |
-            org.opencontainers.image.description=Apache reverse proxy for Mediawiki/Wikibase with static assets
-            org.opencontainers.image.title=Apache Proxy (assets)
+            org.opencontainers.image.description=Apache reverse proxy for Mediawiki/Wikibase with static assets for production
+            org.opencontainers.image.title=Apache Proxy (assets, production)
           annotations: |
-            org.opencontainers.image.description=Apache reverse proxy for Mediawiki/Wikibase with static assets
-            org.opencontainers.image.title=Apache Proxy (assets)
+            org.opencontainers.image.description=Apache reverse proxy for Mediawiki/Wikibase with static assets for production
+            org.opencontainers.image.title=Apache Proxy (assets, production)
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.12.0


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to clarify that the Apache assets build job and its resulting Docker image are specifically intended for production use. The changes mainly involve renaming and updating metadata to avoid confusion between different build environments.

Workflow and Docker image naming:

* Renamed the job from `build-apache-assets` to `build-apache-assets-production` in `.github/workflows/main.yml` to explicitly indicate its production purpose.
* Updated the Docker image name from `apache_assets` to `apache-assets-production` and revised associated labels and annotations to specify that the image is for production use, making the purpose clearer in both the registry and documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration for Apache assets build pipeline with refined image naming and metadata to better distinguish production builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->