### PR TITLE
Enabled MardiImporter extension in production

### DIFF
--- a/LocalSettings.d/base/MardiImport.php
+++ b/LocalSettings.d/base/MardiImport.php
@@ -1,3 +1,3 @@
 <?php
   wfLoadExtension( 'MardiImport' );
-  $wgMardiImportBaseUrl = 'http://importer';
+  $wgMardiImportBaseUrl = 'http://' . getenv( 'IMPORTER_ENDPOINT' );

--- a/LocalSettings.d/base/MardiImport.php
+++ b/LocalSettings.d/base/MardiImport.php
@@ -1,0 +1,3 @@
+<?php
+  wfLoadExtension( 'MardiImport' );
+  $wgMardiImportBaseUrl = 'http://importer';

--- a/LocalSettings.d/staging/MardiImport.php
+++ b/LocalSettings.d/staging/MardiImport.php
@@ -1,3 +1,2 @@
 <?php
-wfLoadExtension( 'MardiImport' );
 $wgMardiImportBaseUrl = 'http://staging-importer';

--- a/LocalSettings.d/staging/MardiImport.php
+++ b/LocalSettings.d/staging/MardiImport.php
@@ -1,2 +1,0 @@
-<?php
-$wgMardiImportBaseUrl = 'http://staging-importer';


### PR DESCRIPTION
# MaRDI Pull Request

# ONLY MERGE WHEN RE-INDEXING IS DONE

**Changes**:
Move MardiImport extension config to base LocalSettings so it loads in all environments, with the importer URL overridden per environment.

- Staging points to http://staging-importer, 
- production uses the default http://importer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated MardiImport extension configuration: base environment now derives the import service endpoint from the deployment environment.
  * Removed explicit MardiImport configuration for the staging environment so it no longer auto-configures or loads the import service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->