### PR TITLE
Add ParserBeforeInternalParse hook for empty text

### DIFF
--- a/LocalSettings.d/production/hooks.php
+++ b/LocalSettings.d/production/hooks.php
@@ -1,16 +1,16 @@
 <?php
 use MediaWiki\Title\Title; 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\Parser;
+
+$wgHooks['ParserBeforeInternalParse'][] =
+	static function ( Parser &$parser, &$text ) {
+		if ( $text === '' ) {
+			$text = '{{global}}';
+		}
+	};
 
 $wgHooks['ArticleViewHeader'][] = function ( Article &$article ) {
-		$content = $article->getPage()->getContent();
-		if ( $content === null ) {
-			return true;
-		}
-		if ( $content->getSize() === 0 ) {
-			$article->getContext()->getOutput()->addWikiTextAsContent( '{{global}}' );
-			return true;
-		}
         $title = $article->getTitle();
         if ( $title->getNamespace() != 120 ) {
                 return true;

--- a/LocalSettings.d/production/hooks.php
+++ b/LocalSettings.d/production/hooks.php
@@ -3,12 +3,17 @@ use MediaWiki\Title\Title;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
 
-$wgHooks['ParserBeforeInternalParse'][] =
-	static function ( Parser &$parser, &$text ) {
-		if ( $text === '' ) {
-			$text = '{{global}}';
-		}
-	};
+$wgHooks['ParserBeforeInternalParse'][] = static function ( Parser &$parser, &$text ) {
+	if ( $text !== '' ) {
+		return;
+	}
+	$page = $parser->getPage();
+	$title = Title::newFromPageReference( $page );
+	if ( $title->getContentModel() !== CONTENT_MODEL_WIKITEXT || !$title->exists() ) {
+		return;
+	}
+	$text = '{{global}}';
+};
 
 $wgHooks['ArticleViewHeader'][] = function ( Article &$article ) {
         $title = $article->getTitle();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Empty pages now show site-wide/global placeholder content during page loads, ensuring users see consistent content instead of a blank page.
  * Article warning behavior preserved and refined so warning messages display reliably while the empty-content handling has been streamlined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->