### PR TITLE
Implement special page lockdowns for user permissions

### DIFF
--- a/LocalSettings.d/base/LocalSettings.override.php
+++ b/LocalSettings.d/base/LocalSettings.override.php
@@ -134,6 +134,12 @@ $wgGroupPermissions['private'] = [];
 $wgGroupPermissions['private']['import'] = true;
 $wgNamespacePermissionLockdown[NS_PRIVATE]['edit'] = [ 'private' ];
 $wgNamespacePermissionLockdown[NS_PRIVATE]['read'] = [ 'private' ];
+# See https://www.mediawiki.org/wiki/Manual:Handling_web_crawlers
+$wgSpecialPageLockdown['Listusers'] = ['user'];
+$wgSpecialPageLockdown['Log'] = ['user'];
+$wgSpecialPageLockdown['Recentchangeslinked'] = ['user'];
+$wgSpecialPageLockdown['Whatlinkshere'] = ['user'];
+$wgActionLockdown['history'] = [ 'user' ];
 
 # Settings for MathSearch extension.
 $fs_host = getenv('MW_FORMULASEARCH_HOST') ?: 'formulasearch';

--- a/LocalSettings.d/base/LocalSettings.override.php
+++ b/LocalSettings.d/base/LocalSettings.override.php
@@ -135,10 +135,11 @@ $wgGroupPermissions['private']['import'] = true;
 $wgNamespacePermissionLockdown[NS_PRIVATE]['edit'] = [ 'private' ];
 $wgNamespacePermissionLockdown[NS_PRIVATE]['read'] = [ 'private' ];
 # See https://www.mediawiki.org/wiki/Manual:Handling_web_crawlers
-$wgSpecialPageLockdown['Listusers'] = ['user'];
-$wgSpecialPageLockdown['Log'] = ['user'];
-$wgSpecialPageLockdown['Recentchangeslinked'] = ['user'];
-$wgSpecialPageLockdown['Whatlinkshere'] = ['user'];
+$wgSpecialPageLockdown['Listusers'] = [ 'user' ];
+$wgSpecialPageLockdown['Log'] = [ 'user' ];
+$wgSpecialPageLockdown['Recentchangeslinked'] = [ 'user' ];
+$wgSpecialPageLockdown['Whatlinkshere'] = [ 'user' ];
+$wgSpecialPageLockdown['EntityData'] = [ 'user' ];
 $wgActionLockdown['history'] = [ 'user' ];
 
 # Settings for MathSearch extension.


### PR DESCRIPTION
Added special page lockdowns for user access control following instructions on https://www.mediawiki.org/wiki/Manual:Handling_web_crawlers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented enhanced access restrictions: several special pages (user lists, logs, linked recent changes, backlinks, entity data) and page history are now limited to registered users only, reducing public visibility of those views and actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->