### PR TITLE
Configure mpm_event_module for increased connections

### DIFF
--- a/apache/mediawiki.conf.template
+++ b/apache/mediawiki.conf.template
@@ -44,4 +44,10 @@ DocumentRoot "/var/www/html"
     RewriteRule ^images/thumb/archive/[0-9a-f]/[0-9a-f][0-9a-f]/([^/]+)/([0-9]+)px-.*$ /w/thumb.php?f=$1&width=$2&archived=1 [L,QSA,B]
 </Directory>
 
+<IfModule mpm_event_module>
+#Increase number of connections
+    ThreadsPerChild      50
+    MaxRequestWorkers    1000
+</IfModule>
+
 AllowEncodedSlashes NoDecode


### PR DESCRIPTION
Added configuration for mpm_event_module to increase connection limits.
At the same time, we should limit the number of connections for not logged in users to the old limit of 400 in Varnish
https://www.mediawiki.org/wiki/Manual:Performance_tuning#Limiting_requests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apache server configuration to optimize performance and increase request handling capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->