### PR TITLE
Google site verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ COPY wait-for-it.sh /wait-for-it.sh
 RUN chmod +x /wait-for-it.sh
 COPY entrypoint.sh /entrypoint.sh
 COPY LocalSettings.php.template /LocalSettings.php.template
+COPY googlef56dee9892c586e7.html /var/www/html/googlef56dee9892c586e7.html
 COPY robots.txt /var/www/html/w/robots.txt
 COPY images /var/www/html/w/images_repo/
 ENV MW_SITE_NAME=wikibase-docker\

--- a/googlef56dee9892c586e7.html
+++ b/googlef56dee9892c586e7.html
@@ -1,0 +1,1 @@
+google-site-verification: googlef56dee9892c586e7.html


### PR DESCRIPTION
Currently, the Google site verification has only been added temporarily. However, to track how many visitors come from Google, we would like to enable this permanently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Google site verification configuration
  * Updated deployment configuration to handle static assets and startup procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->