### PR TITLE
Enable sitemap API and configure namespaces

### DIFF
--- a/LocalSettings.d/base/LocalSettings.override.php
+++ b/LocalSettings.d/base/LocalSettings.override.php
@@ -228,3 +228,8 @@ $GLOBALS['wgHooks']['MWStakeRunJobsTriggerRegisterHandlers'][] = static function
 	];
 	return true;
 };
+
+$wgSitemapApiConfig['enabled'] = true;
+$wgSitemapNamespaces = [
+    0
+];


### PR DESCRIPTION
Only index the main namespace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sitemap API is now available for external access.
  * Sitemap generation is limited to main namespace content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->