### PR TITLE
Install extension ParserMigration

### DIFF
--- a/clone_all.sh
+++ b/clone_all.sh
@@ -43,6 +43,7 @@ EXTENSIONS=(
   "PageForms ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-PageForms.git"
   "PageImages ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-PageImages.git"
   "ParserFunctions ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-ParserFunctions.git"
+  "ParserMigration ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-ParserMigration.git"
   "PdfHandler ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-PdfHandler.git"
   "PluggableAuth master https://github.com/wikimedia/mediawiki-extensions-PluggableAuth.git"
   "Popups ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Popups.git"


### PR DESCRIPTION
Bug: [T429744](https://phabricator.wikimedia.org/T429744)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ParserMigration MediaWiki extension to system setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->