### PR TITLE
Refactor extension cloning list to reduce duplicated URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,38 @@ gh release create v1.47.10 --generate-notes
 
 # Adding extensions
 To install and activate a new extension you have to:
-* Add it to the `clone_all.sh` script in the `EXTENSIONS` array:
 
-`"AdvancedSearch ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-AdvancedSearch.git"`
+* Add it to the `clone_all.sh` script in the `EXTENSIONS` array.
+
+Entries use the format:
+
+```bash
+"name|branch|repo-override"
+```
+
+Rules:
+
+* If `branch` is omitted, `WMF_BRANCH` is used.
+* If `repo-override` is omitted, the standard Wikimedia extension URL is used:
+  `https://github.com/wikimedia/mediawiki-extensions-${name}.git`
+* For ProfessionalWiki repositories, the shorthand
+  `professionalwiki:<repo>` may be used.
+
+Examples:
+
+```bash
+# Standard Wikimedia extension on WMF_BRANCH
+"AdvancedSearch"
+
+# Wikimedia extension on a different branch
+"DataTransfer|${REL_BRANCH}"
+
+# ProfessionalWiki extension
+"ExternalContent|master|professionalwiki:ExternalContent"
+
+# Custom repository
+"AWS|master|https://github.com/edwardspec/mediawiki-aws-s3.git"
+```
 
 * Activate and configure it as required with a corresponding `.php` file placed either directly in the root of `LocalSettings.d` (for global base settings) or inside the `staging/` or `prod/` subdirectories.
 

--- a/clone_all.sh
+++ b/clone_all.sh
@@ -1,15 +1,14 @@
-#!/bin/bash
+#!/bin/bash 
 # cache-bust: 2026-03-31b
 set -euxo pipefail
 
-WMF_BRANCH=wmf/1.47.0-wmf.5
+WMF_BRANCH=wmf/1.47.0-wmf.7
 REL_BRANCH=REL1_45
 
 GITHUB_WIKIMEDIA_EXTENSIONS=https://github.com/wikimedia/mediawiki-extensions
 GITHUB_PROFESSIONALWIKI=https://github.com/ProfessionalWiki
 
-git clone --depth=1 --single-branch -b "$WMF_BRANCH" \
-  https://github.com/wikimedia/mediawiki.git mediawiki
+git clone --depth=1 --single-branch -b "${WMF_BRANCH}" https://github.com/wikimedia/mediawiki.git mediawiki
 
 EXTENSIONS=(
   # name|branch|repo-override
@@ -26,8 +25,8 @@ EXTENSIONS=(
   "CodeEditor"
   "CodeMirror"
   "ConfirmEdit"
-  "DataTransfer|$REL_BRANCH"
-  "DisplayTitle|$REL_BRANCH"
+  "DataTransfer|${REL_BRANCH}"
+  "DisplayTitle|${REL_BRANCH}"
   "Echo"
   "Elastica"
   "EntitySchema"
@@ -38,7 +37,7 @@ EXTENSIONS=(
   "Gadgets"
   "InputBox"
   "JsonConfig"
-  "Lockdown|$REL_BRANCH"
+  "Lockdown|${REL_BRANCH}"
   "MardiImport|main|https://github.com/MaRDI4NFDI/mediawiki-extension-MardiImport.git"
   "Math|master"
   "MathSearch|master"
@@ -46,8 +45,8 @@ EXTENSIONS=(
   "MultimediaViewer"
   "Nuke"
   "OAuth"
-  "OpenIDConnect|$REL_BRANCH"
-  "PageForms|$REL_BRANCH"
+  "OpenIDConnect|${REL_BRANCH}"
+  "PageForms|${REL_BRANCH}"
   "PageImages"
   "ParserFunctions"
   "ParserMigration"
@@ -55,7 +54,7 @@ EXTENSIONS=(
   "PluggableAuth|master"
   "Popups"
   "ProofreadPage"
-  "ReplaceText|$REL_BRANCH"
+  "ReplaceText|${REL_BRANCH}"
   "Scribunto"
   "SemanticDrilldown|master|https://github.com/MaRDI4NFDI/SemanticDrilldown.git"
   "SemanticMediaWiki|master|https://github.com/SemanticMediaWiki/SemanticMediaWiki.git"
@@ -66,89 +65,102 @@ EXTENSIONS=(
   "Thanks"
   "TimedMediaHandler"
   "UniversalLanguageSelector"
-  "UrlGetParameters|$REL_BRANCH"
-  "UserMerge|$REL_BRANCH"
-  "Variables|$REL_BRANCH"
+  "UrlGetParameters|${REL_BRANCH}"
+  "UserMerge|${REL_BRANCH}"
+  "Variables|${REL_BRANCH}"
   "VisualEditor"
-  "Widgets|$REL_BRANCH"
+  "Widgets|${REL_BRANCH}"
   "WikibaseCirrusSearch"
   "WikibaseExport|master|professionalwiki:WikibaseExport"
   "WikibaseFacetedSearch|master|professionalwiki:WikibaseFacetedSearch"
-  # "WikibaseLexeme"
+ # "WikibaseLexeme"
   "WikibaseLocalMedia|master|professionalwiki:WikibaseLocalMedia"
-  "WikibaseManifest|$REL_BRANCH"
+  "WikibaseManifest|${REL_BRANCH}"
   "WikibaseMediaInfo"
   "WikibaseQualityConstraints"
   "WikiEditor"
-  "YouTube|$REL_BRANCH"
+  "YouTube|${REL_BRANCH}"
 )
 
 resolve_repo() {
-  local name=$1
-  local repo=${2:-}
+    REPO=${2:-}
 
-  case "$repo" in
-    "")
-      echo "${GITHUB_WIKIMEDIA_EXTENSIONS}-${name}.git"
-      ;;
-    professionalwiki:*)
-      echo "${GITHUB_PROFESSIONALWIKI}/${repo#professionalwiki:}.git"
-      ;;
-    *)
-      echo "$repo"
-      ;;
-  esac
+    case "$REPO" in
+        "")
+            echo "${GITHUB_WIKIMEDIA_EXTENSIONS}-${1}.git"
+            ;;
+        professionalwiki:*)
+            echo "${GITHUB_PROFESSIONALWIKI}/${REPO#professionalwiki:}.git"
+            ;;
+        *)
+            echo "$REPO"
+            ;;
+    esac
 }
 
-clone_ext() {
-  local name=$1
-  local branch=${2:-$WMF_BRANCH}
-  local repo
+add_submodule() {
+    EXTENSION=$1
+    BRANCH=${2:-$WMF_BRANCH}
+    REPO_URL=$(resolve_repo "$EXTENSION" "${3:-}")
+    
+    # Execute the script with the extension and branch as arguments
+    echo "Cloning ${EXTENSION} (${BRANCH}) from ${REPO_URL}"
 
-  repo=$(resolve_repo "$name" "${3:-}")
-
-  echo "Cloning ${name} (${branch}) from ${repo}"
-
-  git clone --depth=1 --recurse-submodules --single-branch -b "$branch" \
-    "$repo" "mediawiki/extensions/$name"
+    # Clone the repository using the provided URL
+    git clone --depth=1 --recurse-submodules "$REPO_URL" --single-branch -b "$BRANCH" mediawiki/extensions/"$EXTENSION"
 }
 
-for ext in "${EXTENSIONS[@]}"; do
-  IFS='|' read -r name branch repo <<< "$ext"
-  clone_ext "$name" "$branch" "$repo"
+export -f add_submodule
+
+# Run the submodule addition in parallel (degree 10)
+# would require installation of additional package parallel
+# parallel -j 10 add_submodule {1} {2} {3} ::: "${EXTENSIONS[@]}" | awk '{print $1, $2, $3}'
+
+# Track background jobs
+jobs=()
+
+for ext in "${EXTENSIONS[@]}"
+do
+    IFS='|' read -r EXTENSION BRANCH REPO_URL <<< "$ext"
+
+    # Run each add_submodule function in the background
+    add_submodule "$EXTENSION" "$BRANCH" "$REPO_URL"
+    
+    #jobs+=($!)
+
+    # Limit the number of background jobs to 1
+    # if [[ ${#jobs[@]} -ge 1 ]]; then
+        # Wait for the first background job to finish before continuing
+    #    wait "${jobs[0]}"
+        # Remove the completed job from the jobs array
+    #    jobs=("${jobs[@]:1}")
+    #fi
 done
+
+# Wait for any remaining background jobs to finish
+wait
+
+
 
 ## Patch Wikibase
 # cf. https://github.com/wmde/wikibase-release-pipeline/pull/753/files
 # WORKAROUND for https://phabricator.wikimedia.org/T372458
 # Take wikibase submodules from github as phabricator rate limits us
-git clone --depth=1 https://github.com/wikimedia/mediawiki-extensions-Wikibase.git \
-  --single-branch -b "$WMF_BRANCH" mediawiki/extensions/Wikibase
-
-patch -d mediawiki/extensions/Wikibase -Np1 \
-  < ./wikibase-submodules-from-github-instead-of-phabricator.patch
-
-git -C mediawiki/extensions/Wikibase submodule update --init --recursive
+git clone --depth=1 https://github.com/wikimedia/mediawiki-extensions-Wikibase.git --single-branch -b ${WMF_BRANCH} mediawiki/extensions/Wikibase && \
+    patch -d mediawiki/extensions/Wikibase -Np1 <./wikibase-submodules-from-github-instead-of-phabricator.patch && \
+    git -C mediawiki/extensions/Wikibase submodule update --init --recursive    
 
 # Workaround for https://phabricator.wikimedia.org/T388624
-git -C mediawiki/extensions/DisplayTitle fetch \
-  https://gerrit.wikimedia.org/r/mediawiki/extensions/DisplayTitle \
-  refs/changes/48/1126048/1
-
-git -C mediawiki/extensions/DisplayTitle checkout -b change-1126048 FETCH_HEAD
+cd mediawiki/extensions/DisplayTitle
+git fetch https://gerrit.wikimedia.org/r/mediawiki/extensions/DisplayTitle refs/changes/48/1126048/1 && git checkout -b change-1126048 FETCH_HEAD
+cd ../../..
 
 # Clone core and other skins
-git clone --depth=1 https://github.com/wikimedia/mediawiki-skins-Vector \
-  --single-branch -b "$WMF_BRANCH" mediawiki/skins/Vector
-
-git clone --depth=1 https://github.com/ProfessionalWiki/chameleon.git \
-  mediawiki/skins/chameleon
-
-git clone --depth=1 https://github.com/ProfessionalWiki/MardiSkin.git \
-  mediawiki/skins/MardiSkin
+git clone --depth=1 https://github.com/wikimedia/mediawiki-skins-Vector -b ${WMF_BRANCH} mediawiki/skins/Vector
+  # Other skins
+git clone --depth=1 https://github.com/ProfessionalWiki/chameleon.git mediawiki/skins/chameleon 
+git clone --depth=1 https://github.com/ProfessionalWiki/MardiSkin.git mediawiki/skins/MardiSkin
 
 # Temporary dependency fix
 rm -f mediawiki/extensions/DataTransfer/composer.json
-
-sed -i 's/"psr\/http-message": "\^1"/"psr\/http-message": "^1 || ^2"/' \
-  mediawiki/skins/chameleon/composer.json
+sed -i 's/"psr\/http-message": "\^1"/"psr\/http-message": "^1 || ^2"/' mediawiki/skins/chameleon/composer.json

--- a/clone_all.sh
+++ b/clone_all.sh
@@ -1,147 +1,154 @@
-#!/bin/bash 
+#!/bin/bash
 # cache-bust: 2026-03-31b
 set -euxo pipefail
 
-WMF_BRANCH=wmf/1.47.0-wmf.7
+WMF_BRANCH=wmf/1.47.0-wmf.5
 REL_BRANCH=REL1_45
 
-git clone --depth=1 --single-branch -b "${WMF_BRANCH}" https://github.com/wikimedia/mediawiki.git mediawiki
+GITHUB_WIKIMEDIA_EXTENSIONS=https://github.com/wikimedia/mediawiki-extensions
+GITHUB_PROFESSIONALWIKI=https://github.com/ProfessionalWiki
+
+git clone --depth=1 --single-branch -b "$WMF_BRANCH" \
+  https://github.com/wikimedia/mediawiki.git mediawiki
 
 EXTENSIONS=(
-  "AdvancedSearch ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-AdvancedSearch.git"
-  "AWS master https://github.com/edwardspec/mediawiki-aws-s3.git"
-  "ArticlePlaceholder ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-ArticlePlaceholder.git"
-  "Babel ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Babel.git"
-  "CirrusSearch ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-CirrusSearch.git"
-  "Cite ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Cite.git"
-  "CiteThisPage ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-CiteThisPage.git"
-  "cldr ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-cldr.git"
-  "CodeEditor ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-CodeEditor.git"
-  "CodeMirror ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-CodeMirror.git"
-  "ConfirmEdit ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-ConfirmEdit.git"
-  "DataTransfer ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-DataTransfer.git"
-  "DisplayTitle ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-DisplayTitle.git"
-  "Echo ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Echo.git"
-  "Elastica ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Elastica.git"
-  "EntitySchema ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-EntitySchema.git"
-  "EventBus ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-EventBus.git"
-  "EventStreamConfig ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-EventStreamConfig.git"
-  "ExternalContent master https://github.com/ProfessionalWiki/ExternalContent.git"
-  "ExternalData master https://github.com/wikimedia/mediawiki-extensions-ExternalData.git"
-  "Gadgets ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Gadgets.git"
-  "InputBox ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-InputBox.git"
-  "JsonConfig ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-JsonConfig.git"
-  "Lockdown ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Lockdown.git"
-  "MardiImport main https://github.com/MaRDI4NFDI/mediawiki-extension-MardiImport.git"
-  "Math master https://github.com/wikimedia/mediawiki-extensions-Math.git"
-  "MathSearch master https://github.com/wikimedia/mediawiki-extensions-MathSearch.git"
-  "MatomoAnalytics main https://github.com/miraheze/MatomoAnalytics.git"
-  "MultimediaViewer ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-MultimediaViewer.git"
-  "Nuke ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Nuke.git"
-  "OAuth ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-OAuth.git"
-  "OpenIDConnect ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-OpenIDConnect.git"
-  "PageForms ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-PageForms.git"
-  "PageImages ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-PageImages.git"
-  "ParserFunctions ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-ParserFunctions.git"
-  "ParserMigration ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-ParserMigration.git"
-  "PdfHandler ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-PdfHandler.git"
-  "PluggableAuth master https://github.com/wikimedia/mediawiki-extensions-PluggableAuth.git"
-  "Popups ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Popups.git"
-  "ProofreadPage ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-ProofreadPage.git"
-  "ReplaceText ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-ReplaceText.git"
-  "Scribunto ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Scribunto.git"
-  "SemanticDrilldown master https://github.com/MaRDI4NFDI/SemanticDrilldown.git"
-  "SemanticMediaWiki master https://github.com/SemanticMediaWiki/SemanticMediaWiki.git"
-  "SPARQL master https://github.com/ProfessionalWiki/SPARQL.git"
-  "SyntaxHighlight_GeSHi ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-SyntaxHighlight_GeSHi.git"
-  "TemplateStyles ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-TemplateStyles.git"
-  "TextExtracts ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-TextExtracts.git"
-  "Thanks ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Thanks.git"
-  "TimedMediaHandler ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-TimedMediaHandler.git"
-  "UniversalLanguageSelector ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector.git"
-  "UrlGetParameters ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-UrlGetParameters.git"
-  "UserMerge ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-UserMerge.git"
-  "Variables ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Variables.git"
-  "VisualEditor ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-VisualEditor.git"
-  "Widgets ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Widgets.git"
-  "WikibaseCirrusSearch ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikibaseCirrusSearch.git"
-  "WikibaseExport master https://github.com/ProfessionalWiki/WikibaseExport.git"
-  "WikibaseFacetedSearch master https://github.com/ProfessionalWiki/WikibaseFacetedSearch.git"
- # "WikibaseLexeme ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikibaseLexeme.git"
-  "WikibaseLocalMedia master https://github.com/ProfessionalWiki/WikibaseLocalMedia.git"
-  "WikibaseManifest ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikibaseManifest.git"
-  "WikibaseMediaInfo ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikibaseMediaInfo.git"
-  "WikibaseQualityConstraints ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikibaseQualityConstraints.git"
-  "WikiEditor ${WMF_BRANCH} https://github.com/wikimedia/mediawiki-extensions-WikiEditor.git"
-  "YouTube ${REL_BRANCH} https://github.com/wikimedia/mediawiki-extensions-YouTube.git"
+  # name|branch|repo-override
+  # If branch is omitted, WMF_BRANCH is used.
+  # If repo-override is omitted, Wikimedia's standard extension URL is used.
+  "AdvancedSearch"
+  "AWS|master|https://github.com/edwardspec/mediawiki-aws-s3.git"
+  "ArticlePlaceholder"
+  "Babel"
+  "CirrusSearch"
+  "Cite"
+  "CiteThisPage"
+  "cldr"
+  "CodeEditor"
+  "CodeMirror"
+  "ConfirmEdit"
+  "DataTransfer|$REL_BRANCH"
+  "DisplayTitle|$REL_BRANCH"
+  "Echo"
+  "Elastica"
+  "EntitySchema"
+  "EventBus"
+  "EventStreamConfig"
+  "ExternalContent|master|professionalwiki:ExternalContent"
+  "ExternalData|master"
+  "Gadgets"
+  "InputBox"
+  "JsonConfig"
+  "Lockdown|$REL_BRANCH"
+  "MardiImport|main|https://github.com/MaRDI4NFDI/mediawiki-extension-MardiImport.git"
+  "Math|master"
+  "MathSearch|master"
+  "MatomoAnalytics|main|https://github.com/miraheze/MatomoAnalytics.git"
+  "MultimediaViewer"
+  "Nuke"
+  "OAuth"
+  "OpenIDConnect|$REL_BRANCH"
+  "PageForms|$REL_BRANCH"
+  "PageImages"
+  "ParserFunctions"
+  "ParserMigration"
+  "PdfHandler"
+  "PluggableAuth|master"
+  "Popups"
+  "ProofreadPage"
+  "ReplaceText|$REL_BRANCH"
+  "Scribunto"
+  "SemanticDrilldown|master|https://github.com/MaRDI4NFDI/SemanticDrilldown.git"
+  "SemanticMediaWiki|master|https://github.com/SemanticMediaWiki/SemanticMediaWiki.git"
+  "SPARQL|master|professionalwiki:SPARQL"
+  "SyntaxHighlight_GeSHi"
+  "TemplateStyles"
+  "TextExtracts"
+  "Thanks"
+  "TimedMediaHandler"
+  "UniversalLanguageSelector"
+  "UrlGetParameters|$REL_BRANCH"
+  "UserMerge|$REL_BRANCH"
+  "Variables|$REL_BRANCH"
+  "VisualEditor"
+  "Widgets|$REL_BRANCH"
+  "WikibaseCirrusSearch"
+  "WikibaseExport|master|professionalwiki:WikibaseExport"
+  "WikibaseFacetedSearch|master|professionalwiki:WikibaseFacetedSearch"
+  # "WikibaseLexeme"
+  "WikibaseLocalMedia|master|professionalwiki:WikibaseLocalMedia"
+  "WikibaseManifest|$REL_BRANCH"
+  "WikibaseMediaInfo"
+  "WikibaseQualityConstraints"
+  "WikiEditor"
+  "YouTube|$REL_BRANCH"
 )
 
-add_submodule() {
-    EXTENSION=$1
-    BRANCH=$2
-    REPO_URL=$3
-    
-    # Execute the script with the extension and branch as arguments
-    echo "Cloning ${EXTENSION} (${BRANCH}) from ${REPO_URL}"
+resolve_repo() {
+  local name=$1
+  local repo=${2:-}
 
-    # Clone the repository using the provided URL
-    git clone --depth=1 --recurse-submodules "$REPO_URL" --single-branch -b "$BRANCH" mediawiki/extensions/"$EXTENSION"
+  case "$repo" in
+    "")
+      echo "${GITHUB_WIKIMEDIA_EXTENSIONS}-${name}.git"
+      ;;
+    professionalwiki:*)
+      echo "${GITHUB_PROFESSIONALWIKI}/${repo#professionalwiki:}.git"
+      ;;
+    *)
+      echo "$repo"
+      ;;
+  esac
 }
 
-export -f add_submodule
+clone_ext() {
+  local name=$1
+  local branch=${2:-$WMF_BRANCH}
+  local repo
 
-# Run the submodule addition in parallel (degree 10)
-# would require installation of additional package parallel
-# parallel -j 10 add_submodule {1} {2} {3} ::: "${EXTENSIONS[@]}" | awk '{print $1, $2, $3}'
+  repo=$(resolve_repo "$name" "${3:-}")
 
-# Track background jobs
-jobs=()
+  echo "Cloning ${name} (${branch}) from ${repo}"
 
-for ext in "${EXTENSIONS[@]}"
-do
-    # Split the extension name, branch, and URL using space as delimiter
-    EXTENSION=$(echo "$ext" | awk '{print $1}')
-    BRANCH=$(echo "$ext" | awk '{print $2}')
-    REPO_URL=$(echo "$ext" | awk '{print $3}')
+  git clone --depth=1 --recurse-submodules --single-branch -b "$branch" \
+    "$repo" "mediawiki/extensions/$name"
+}
 
-    # Run each add_submodule function in the background
-    add_submodule "$EXTENSION" "$BRANCH" "$REPO_URL"
-    
-    #jobs+=($!)
-
-    # Limit the number of background jobs to 1
-    # if [[ ${#jobs[@]} -ge 1 ]]; then
-        # Wait for the first background job to finish before continuing
-    #    wait "${jobs[0]}"
-        # Remove the completed job from the jobs array
-    #    jobs=("${jobs[@]:1}")
-    #fi
+for ext in "${EXTENSIONS[@]}"; do
+  IFS='|' read -r name branch repo <<< "$ext"
+  clone_ext "$name" "$branch" "$repo"
 done
-
-# Wait for any remaining background jobs to finish
-wait
-
-
 
 ## Patch Wikibase
 # cf. https://github.com/wmde/wikibase-release-pipeline/pull/753/files
 # WORKAROUND for https://phabricator.wikimedia.org/T372458
 # Take wikibase submodules from github as phabricator rate limits us
-git clone --depth=1 https://github.com/wikimedia/mediawiki-extensions-Wikibase.git --single-branch -b ${WMF_BRANCH} mediawiki/extensions/Wikibase && \
-    patch -d mediawiki/extensions/Wikibase -Np1 <./wikibase-submodules-from-github-instead-of-phabricator.patch && \
-    git -C mediawiki/extensions/Wikibase submodule update --init --recursive    
+git clone --depth=1 https://github.com/wikimedia/mediawiki-extensions-Wikibase.git \
+  --single-branch -b "$WMF_BRANCH" mediawiki/extensions/Wikibase
+
+patch -d mediawiki/extensions/Wikibase -Np1 \
+  < ./wikibase-submodules-from-github-instead-of-phabricator.patch
+
+git -C mediawiki/extensions/Wikibase submodule update --init --recursive
 
 # Workaround for https://phabricator.wikimedia.org/T388624
-cd mediawiki/extensions/DisplayTitle
-git fetch https://gerrit.wikimedia.org/r/mediawiki/extensions/DisplayTitle refs/changes/48/1126048/1 && git checkout -b change-1126048 FETCH_HEAD
-cd ../../..
+git -C mediawiki/extensions/DisplayTitle fetch \
+  https://gerrit.wikimedia.org/r/mediawiki/extensions/DisplayTitle \
+  refs/changes/48/1126048/1
+
+git -C mediawiki/extensions/DisplayTitle checkout -b change-1126048 FETCH_HEAD
 
 # Clone core and other skins
-git clone --depth=1 https://github.com/wikimedia/mediawiki-skins-Vector -b ${WMF_BRANCH} mediawiki/skins/Vector
-  # Other skins
-git clone --depth=1 https://github.com/ProfessionalWiki/chameleon.git mediawiki/skins/chameleon 
-git clone --depth=1 https://github.com/ProfessionalWiki/MardiSkin.git mediawiki/skins/MardiSkin
+git clone --depth=1 https://github.com/wikimedia/mediawiki-skins-Vector \
+  --single-branch -b "$WMF_BRANCH" mediawiki/skins/Vector
+
+git clone --depth=1 https://github.com/ProfessionalWiki/chameleon.git \
+  mediawiki/skins/chameleon
+
+git clone --depth=1 https://github.com/ProfessionalWiki/MardiSkin.git \
+  mediawiki/skins/MardiSkin
 
 # Temporary dependency fix
 rm -f mediawiki/extensions/DataTransfer/composer.json
-sed -i 's/"psr\/http-message": "\^1"/"psr\/http-message": "^1 || ^2"/' mediawiki/skins/chameleon/composer.json
+
+sed -i 's/"psr\/http-message": "\^1"/"psr\/http-message": "^1 || ^2"/' \
+  mediawiki/skins/chameleon/composer.json


### PR DESCRIPTION
This PR refactors the extension cloning script to make the extension list easier to maintain.

Changes:

* keep all extensions in one alphabetically ordered list
* use |-separated fields instead of space splitting, 
   default to the standard Wikimedia extension repository URL, 
   default to WMF_BRANCH when no branch is specified
* add a professionalwiki: shorthand for ProfessionalWiki repositories,
   keep non-standard repositories explicit

This reduces copy-paste when adding extensions and makes it easier to check whether an extension is already listed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored repository checkout configuration in the extension cloning tool to support more flexible branch and repository overrides while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->