### PR TITLE
Fix WikibaseLocalMedia crash on MW 1.47 (OutputPage::parserOptions removed)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch -text

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 
 WORKDIR /
 
-COPY wikibase-submodules-from-github-instead-of-phabricator.patch clone_all.sh ./
+COPY wikibase-submodules-from-github-instead-of-phabricator.patch wikibase-local-media-parser-options.patch clone_all.sh ./
 
 RUN bash clone_all.sh
 

--- a/clone_all.sh
+++ b/clone_all.sh
@@ -149,7 +149,9 @@ wait
 git clone --depth=1 https://github.com/wikimedia/mediawiki-extensions-Wikibase.git --single-branch -b ${WMF_BRANCH} mediawiki/extensions/Wikibase && \
     patch -d mediawiki/extensions/Wikibase -Np1 <./wikibase-submodules-from-github-instead-of-phabricator.patch && \
     git -C mediawiki/extensions/Wikibase submodule update --init --recursive    
-
+# Temporary fix: WikibaseLocalMedia crashes on MW 1.47 (OutputPage::parserOptions() removed).
+# Remove once upstream merges https://github.com/ProfessionalWiki/WikibaseLocalMedia/pull/46
+patch -d mediawiki/extensions/WikibaseLocalMedia -Np1 <./wikibase-local-media-parser-options.patch
 # Workaround for https://phabricator.wikimedia.org/T388624
 cd mediawiki/extensions/DisplayTitle
 git fetch https://gerrit.wikimedia.org/r/mediawiki/extensions/DisplayTitle refs/changes/48/1126048/1 && git checkout -b change-1126048 FETCH_HEAD

--- a/wikibase-local-media-parser-options.patch
+++ b/wikibase-local-media-parser-options.patch
@@ -1,0 +1,19 @@
+--- a/src/Services/FormatterBuilder.php	2026-07-15 08:29:41.078360443 +0000
++++ b/src/Services/FormatterBuilder.php	2026-07-15 09:56:24.441137709 +0000
+@@ -4,6 +4,7 @@
+ 
+ namespace Wikibase\LocalMedia\Services;
+ 
++use ParserOptions;
+ use RequestContext;
+ use ValueFormatters\FormatterOptions;
+ use ValueFormatters\ValueFormatter;
+@@ -27,7 +28,7 @@
+ 
+ 		if ( $snakFormat->isPossibleFormat( SnakFormatter::FORMAT_HTML_VERBOSE, $format ) ) {
+ 			return new InlineImageFormatter(
+-				RequestContext::getMain()->getOutput()->parserOptions(),
++				ParserOptions::newFromContext( RequestContext::getMain() ),
+ 				$this->thumbLimits,
+ 				$options->getOption( ValueFormatter::OPT_LANG ),
+ 				new LocalImageLinker(),


### PR DESCRIPTION
## Problem

Item pages with a `localMedia` statement fail with an internal error on staging, e.g.
https://staging.mardi4nfdi.org/wiki/Item:Q4610:

    Error: Call to undefined method MediaWiki\Output\OutputPage::parserOptions()
    from extensions/WikibaseLocalMedia/src/Services/FormatterBuilder.php(30)

`OutputPage::parserOptions()` was deprecated in MW 1.44 and no longer exists in
`wmf/1.47.0-wmf.9` (the branch this image builds, see `clone_all.sh`).

Note this is a second, separate incompatibility from the one reported in
MaRDI4NFDI/MaRDIRoadmap#208: that crash (`ArgumentCountError` in
`File::getDimensionsString()`) was fixed upstream in WikibaseLocalMedia 2.0.1,
which the image already gets by cloning `master`. This `parserOptions` crash
occurs earlier in the same code path and blocks the same pages.

## Fix

Upstream fix exists but is not merged yet:
https://github.com/ProfessionalWiki/WikibaseLocalMedia/pull/46

This PR applies the equivalent one-line change at image build time, following
the repo's existing patch convention (`patch -Np1` in `clone_all.sh`):

- `FormatterBuilder.php`: `RequestContext::getMain()->getOutput()->parserOptions()`
  → `ParserOptions::newFromContext( RequestContext::getMain() )`

`ParserOptions::newFromContext()` is the documented replacement and exists in
both older and current MediaWiki, so the patch is version-safe. The patch is
verified to apply cleanly against current WikibaseLocalMedia `master`.

Also adds `.gitattributes` with `*.patch -text` so patch files are never
subject to line-ending conversion.

**This is a temporary workaround** — remove the patch once upstream merges
PR 46 and cuts a release.

## After merge

- Bump the image tag in `portal-k8s` `apps/staging/wikibase/values-staging.yaml`
  (currently `sha-9991dbc`) to the new build.
- Verify https://staging.mardi4nfdi.org/wiki/Item:Q4610 renders, including the
  image dimensions caption (that caption also exercises the 2.0.1 fix for the
  original #208 error).

Refs MaRDI4NFDI/MaRDIRoadmap#208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a compatibility issue that could cause crashes when running Wikibase Local Media with MediaWiki 1.47.
  * Improved image formatting by ensuring parser options are obtained through the supported interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->