### PR TITLE
Remove sectionsByDB

### DIFF
--- a/LocalSettings.d/00_database.php
+++ b/LocalSettings.d/00_database.php
@@ -38,14 +38,8 @@ if ( getenv('DB_PRIMARY_IP') && getenv('DB_SECONDARY_IP') ) {
 
 		'class' => 'LBFactoryMulti',
 
-		'sectionsByDB' => array(
-            'staging_wiki' => 's1',
-			'my_wiki' => 's1', 
-			'wiki_swmath' => 's1',
-		),
-
 		'sectionLoads' => array(
-			's1' => array(
+			'DEFAULT' => array(
 				getenv('DB_PRIMARY_IP') => 0,
 				getenv('DB_SECONDARY_IP') => 100,
 			),


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- I suggest removing the `sectionsByDB` section to just use DEFAULT. 
- This should fix the error messages mentioned in https://github.com/MaRDI4NFDI/docker-wikibase/issues/336 which I think are triggered by the non-existent language DBs (en.wiki.., de.wiki..)

Otherwise we could also comment out until it is necessary:
```
$wikibase_host = getenv( 'WIKIBASE_HOST' );
if ( preg_match( '/^([0-9a-z-]+)\.(wik.*?)' . $wikibase_host . '$/', $host, $match ) !== 1 ) {
	die( "Server name $host does not match the patterns for wikis." );
}
$lang = str_replace( '-', '_', $match[1] );
$suffix = str_replace( '.', '', $match[2] );
$wgDBname = $lang . $suffix;
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database load-balancer configuration to use the default section when primary and secondary database addresses are configured.
  * Simplified connection routing configuration for improved compatibility with the updated setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->