### PR TITLE
Add expensive parser function limit for Scribunto

### DIFF
--- a/LocalSettings.d/Scribunto.php
+++ b/LocalSettings.d/Scribunto.php
@@ -2,3 +2,4 @@
 ## Scribunto 
 wfLoadExtension( 'Scribunto' );
 $wgScribuntoDefaultEngine = 'luastandalone';
+$wgExpensiveParserFunctionLimit=250;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Increased the limit for expensive parser functions to 250.
  * Retained LuaStandalone as the default Scribunto engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->