### PR TITLE
restore overwrite baseUri in staging

### DIFF
--- a/LocalSettings.d/staging/zz_overwrite_baseUri.php
+++ b/LocalSettings.d/staging/zz_overwrite_baseUri.php
@@ -1,0 +1,30 @@
+<?php
+
+$wgWBClientSettings['entitySources'] = [
+    'mardi_source' => [
+        'repoDatabase' => 'my_wiki',
+        'baseUri' => 'http://'. getenv( 'WIKIBASE_HOST' ) . '/entity/',
+        'entityNamespaces' => [
+            'item' => 120,
+            'property' => 122,
+        ],
+        'rdfNodeNamespacePrefix' => 'wd',
+        'rdfPredicateNamespacePrefix' => '',
+        'interwikiPrefix' => '',
+    ],
+];
+
+$wgWBRepoSettings['entitySources'] = [
+      'mardi_source' => [
+        'repoDatabase' => 'my_wiki',
+        'baseUri' => 'http://'. getenv( 'WIKIBASE_HOST' ) . '/entity/',
+        'entityNamespaces' => [
+            'item' => 120,
+            'property' => 122,
+        ],
+        'rdfNodeNamespacePrefix' => 'wd',
+        'rdfPredicateNamespacePrefix' => '',
+        'interwikiPrefix' => '',
+      ],
+
+  ];


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- This file was deleted https://github.com/MaRDI4NFDI/docker-wikibase/commit/51395fcdcf12492ff0c7dce65e7c3a43bba6bf82 but it is necessary for the qlever updater configuration, which stopped working as a result.
- I am restoring it here. 

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staging configuration for Wikibase client and repository entity sources.
  * Enabled environment-based host settings, item and property namespaces, RDF prefixes, and interwiki configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->