### PR TITLE
Load deployment env files at the end

### DIFF
--- a/LocalSettings.d/LocalSettings.override.php
+++ b/LocalSettings.d/LocalSettings.override.php
@@ -237,13 +237,11 @@ $wgSitemapNamespaces = [
 	0
 ];
 
+# The settings in LocalSettings.d/$DEPLOYMENT_ENV/ are included by
+# zzz_deployment_env.php, which sorts last in LocalSettings.d so that they
+# override every other file. Here we only resolve the name for the credits below.
 $deployment_env = getenv( 'DEPLOYMENT_ENV' );
-if ( $deployment_env && is_dir( "/var/www/html/w/LocalSettings.d/$deployment_env" ) ) {
-	foreach ( glob( "/var/www/html/w/LocalSettings.d/$deployment_env/*.php" ) as $filename ) {
-		include $filename;
-	}
-} else {
-	wfDebug( "DEPLOYMENT_ENV not specified or directory does not exist, skipping environment-specific settings." );
+if ( !$deployment_env || !is_dir( "/var/www/html/w/LocalSettings.d/$deployment_env" ) ) {
 	$deployment_env = 'unknown';
 }
 

--- a/LocalSettings.d/zzz_deployment_env.php
+++ b/LocalSettings.d/zzz_deployment_env.php
@@ -1,0 +1,17 @@
+<?php
+# Load the deployment-tier settings from LocalSettings.d/$DEPLOYMENT_ENV/ (staging/, prod/).
+#
+# LocalSettings.php includes LocalSettings.d/*.php in glob() order, which is
+# alphabetical. This file is named so that it sorts after every other file in
+# that directory, which makes the environment-specific settings true overrides
+# of the global baseline (Wikibase.php, swmath.php, ...) rather than being
+# silently overwritten by it.
+
+$deployment_env = getenv( 'DEPLOYMENT_ENV' );
+if ( $deployment_env && is_dir( "/var/www/html/w/LocalSettings.d/$deployment_env" ) ) {
+	foreach ( glob( "/var/www/html/w/LocalSettings.d/$deployment_env/*.php" ) as $deployment_env_file ) {
+		include $deployment_env_file;
+	}
+} else {
+	wfDebug( "DEPLOYMENT_ENV not specified or directory does not exist, skipping environment-specific settings." );
+}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The `LocalSettings.d` directory isolates runtime configuration rules. Files are 
 * **`staging/`**: Contains target configuration layers (such as test overrides and custom captcha engines) injected exclusively during staging builds.
 * **`prod/`**: Contains target infrastructure parameters (including production performance logging frameworks and live SPARQL configurations) executed strictly within live release tags.
 
+Loading order: `LocalSettings.php` includes the root `LocalSettings.d/*.php` files in alphabetical order (the glob is *not* recursive). The subdirectory matching `$DEPLOYMENT_ENV` is then included by `zzz_deployment_env.php`, which is named so that it sorts last — the tier-specific files are therefore loaded after every baseline file and genuinely override it. Keep that name sorting last when adding new files to the root of `LocalSettings.d`.
+
 # Create tag and new release
 
 ## Option 1


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- The specific configuration files for staging and deployment were loading as part of LocalSettings.override.php but partially overwritten later by other files that alphabetically come after LocalSettings.override.php
- This PR makes sure that the environment specific files are loaded last.  

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
